### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://destinytl-outlook.visualstudio.com/b767a20f-997c-43ce-86fb-18338f5502bd/2aebfe64-b2db-4c1b-b216-c29f33983450/_apis/work/boardbadge/6dbde30c-c76f-4f7c-b3dc-d01d2129a0b2)](https://destinytl-outlook.visualstudio.com/b767a20f-997c-43ce-86fb-18338f5502bd/_boards/board/t/2aebfe64-b2db-4c1b-b216-c29f33983450/Microsoft.RequirementCategory)
 # LeetCode
 LeetCode刷题记录


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.